### PR TITLE
feat: add quest map and learning rewards

### DIFF
--- a/src/components/CreativeStudio.tsx
+++ b/src/components/CreativeStudio.tsx
@@ -1,0 +1,120 @@
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { ArrowLeft, Paintbrush } from "lucide-react";
+
+interface CreativeStudioProps {
+  stars: number;
+  unlockedSkins: string[];
+  activeSkin?: string;
+  onUnlock: (skinId: string, cost: number) => void;
+  onEquip: (skinId: string) => void;
+  onBack: () => void;
+  simpleMode: boolean;
+}
+
+const skinCatalog = [
+  {
+    id: "classic",
+    name: "Classic Jungle",
+    cost: 0,
+    description: "Green glow with forest freckles.",
+    colors: ["#22c55e", "#166534"],
+  },
+  {
+    id: "sunburst",
+    name: "Sunburst Sprint",
+    cost: 60,
+    description: "Orange and yellow gradient inspired by desert sunsets.",
+    colors: ["#f97316", "#facc15"],
+  },
+  {
+    id: "nebula",
+    name: "Nebula Night",
+    cost: 80,
+    description: "Cosmic purples with star sparkles for galaxy explorers.",
+    colors: ["#a855f7", "#6366f1"],
+  },
+  {
+    id: "geo",
+    name: "Geo Glider",
+    cost: 50,
+    description: "Geometry Grove inspired with teal triangles and lines.",
+    colors: ["#0ea5e9", "#14b8a6"],
+  },
+];
+
+export const CreativeStudio = ({ stars, unlockedSkins, activeSkin, onUnlock, onEquip, onBack, simpleMode }: CreativeStudioProps) => {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-violet-900 to-fuchsia-900 text-white p-4 md:p-8">
+      <div className="max-w-5xl mx-auto space-y-6">
+        <div className="flex items-center justify-between">
+          <Button variant="ghost" onClick={onBack} className="text-white/80 hover:text-white">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            {simpleMode ? "Back" : "Back to map"}
+          </Button>
+          <Badge variant="secondary" className="bg-amber-400/20 text-amber-100 border-amber-300/40">
+            ⭐ {stars} {simpleMode ? "Stars" : "Design stars"}
+          </Badge>
+        </div>
+
+        <div className="text-center space-y-2">
+          <h1 className="text-4xl font-extrabold">{simpleMode ? "Snake Skins" : "Creative Studio"}</h1>
+          <p className="text-white/80 max-w-2xl mx-auto">
+            {simpleMode
+              ? "Spend stars to paint your snake. Each skin makes the arcade stage sparkle!"
+              : "Design your dream snake using stars earned from quests and micro-challenges. Unlock a skin after you finish a chapter quiz."}
+          </p>
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-5">
+          {skinCatalog.map(skin => {
+            const unlocked = unlockedSkins.includes(skin.id);
+            const equipped = activeSkin === skin.id;
+            return (
+              <Card key={skin.id} className="bg-white/10 border-white/20 text-white p-6 flex flex-col gap-4">
+                <div className="flex items-center gap-3">
+                  <div className="h-14 w-14 rounded-full border border-white/40 flex items-center justify-center">
+                    <div className="h-10 w-10 rounded-full" style={{
+                      background: `linear-gradient(135deg, ${skin.colors[0]}, ${skin.colors[1]})`,
+                    }} />
+                  </div>
+                  <div>
+                    <h2 className="text-xl font-bold">{skin.name}</h2>
+                    <p className="text-sm text-white/70">{skin.description}</p>
+                  </div>
+                </div>
+
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-white/80">Cost: {skin.cost} ⭐</span>
+                  {equipped && <Badge variant="secondary" className="bg-emerald-500/30 text-emerald-100 border-emerald-200/30">Equipped</Badge>}
+                </div>
+
+                <div className="flex gap-3">
+                  {!unlocked ? (
+                    <Button
+                      className="flex-1 bg-amber-400 text-slate-900 hover:bg-amber-300"
+                      disabled={stars < skin.cost}
+                      onClick={() => onUnlock(skin.id, skin.cost)}
+                    >
+                      <Paintbrush className="mr-2 h-4 w-4" />
+                      {simpleMode ? "Buy" : "Unlock skin"}
+                    </Button>
+                  ) : (
+                    <Button
+                      className="flex-1 bg-emerald-500 text-emerald-950 hover:bg-emerald-400"
+                      variant={equipped ? "default" : "secondary"}
+                      onClick={() => onEquip(skin.id)}
+                    >
+                      {equipped ? (simpleMode ? "Ready" : "Equipped") : (simpleMode ? "Wear" : "Equip skin")}
+                    </Button>
+                  )}
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/LeaderboardPanel.tsx
+++ b/src/components/LeaderboardPanel.tsx
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { ArrowLeft, Medal, Percent } from "lucide-react";
+import { type LeaderboardProfile } from "@/types/userProgress";
+
+interface LeaderboardPanelProps {
+  onBack: () => void;
+  percentile: number;
+  averageScore: number;
+  profile?: LeaderboardProfile;
+  onSaveProfile: (profile: LeaderboardProfile) => void;
+  simpleMode: boolean;
+}
+
+const percentileBand = (percentile: number) => {
+  if (percentile >= 90) return "Galaxy Genius";
+  if (percentile >= 75) return "Star Scholar";
+  if (percentile >= 50) return "Trailblazer";
+  return "Bright Beginner";
+};
+
+export const LeaderboardPanel = ({ onBack, percentile, averageScore, profile, onSaveProfile, simpleMode }: LeaderboardPanelProps) => {
+  const [nickname, setNickname] = useState(profile?.nickname ?? "");
+  const [classCode, setClassCode] = useState(profile?.classCode ?? "");
+
+  const bandName = percentileBand(percentile);
+
+  const handleSave = () => {
+    const cleanNickname = nickname.trim().slice(0, 12) || "SneakyHero";
+    onSaveProfile({ nickname: cleanNickname, classCode: classCode.trim() || undefined, percentileBand: bandName });
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-white p-4 md:p-8">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <Button variant="ghost" onClick={onBack} className="text-white/80 hover:text-white">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          {simpleMode ? "Back" : "Back to home"}
+        </Button>
+
+        <Card className="bg-slate-900 border-slate-700 p-6 space-y-4">
+          <div className="flex items-center gap-3">
+            <Medal className="h-8 w-8 text-amber-400" />
+            <div>
+              <p className="text-sm uppercase tracking-wide text-slate-400">Safe leaderboard</p>
+              <h1 className="text-3xl font-bold">{bandName}</h1>
+            </div>
+          </div>
+
+          <div className="grid md:grid-cols-2 gap-4">
+            <Card className="bg-slate-800 border-slate-700 p-4">
+              <p className="text-sm text-slate-300">Percentile band</p>
+              <p className="text-2xl font-bold text-white">Top {Math.max(100 - percentile, 1)}%</p>
+              <p className="text-xs text-slate-400 mt-1">We show bands not ranks to keep competition kind.</p>
+            </Card>
+            <Card className="bg-slate-800 border-slate-700 p-4">
+              <p className="text-sm text-slate-300">Average score</p>
+              <p className="text-2xl font-bold text-white">{averageScore.toFixed(0)}%</p>
+              <p className="text-xs text-slate-400 mt-1">Based on last 10 quizzes or lessons.</p>
+            </Card>
+          </div>
+
+          <div className="bg-slate-800/70 border border-slate-700 rounded-2xl p-4 space-y-3">
+            <h2 className="text-lg font-semibold flex items-center gap-2">
+              <Percent className="h-5 w-5 text-amber-300" />
+              {simpleMode ? "Make a nickname" : "Create a device-only nickname"}
+            </h2>
+            <div className="grid md:grid-cols-2 gap-3">
+              <Input
+                value={nickname}
+                onChange={event => setNickname(event.target.value.replace(/[^a-zA-Z0-9_-]/g, ""))}
+                placeholder="RainbowRider"
+                maxLength={12}
+                aria-label="Leaderboard nickname"
+              />
+              <Input
+                value={classCode}
+                onChange={event => setClassCode(event.target.value.replace(/[^A-Z0-9]/g, "").toUpperCase())}
+                placeholder="CLASS123"
+                aria-label="Class code (optional)"
+              />
+            </div>
+            <p className="text-xs text-slate-400">
+              {simpleMode
+                ? "Nicknames stay on this device."
+                : "Nicknames stay on this device and can be shared with teachers using a class code."}
+            </p>
+            <Button onClick={handleSave} className="bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold">
+              {simpleMode ? "Save" : "Save profile"}
+            </Button>
+          </div>
+
+          <div className="grid sm:grid-cols-2 gap-3 text-sm text-slate-300">
+            <Badge variant="outline" className="border-amber-400/40 text-amber-200">No personal info</Badge>
+            <Badge variant="outline" className="border-emerald-400/40 text-emerald-200">Device-only leaderboard</Badge>
+            <Badge variant="outline" className="border-sky-400/40 text-sky-200">Class code optional</Badge>
+            <Badge variant="outline" className="border-fuchsia-400/40 text-fuchsia-200">Celebrate effort</Badge>
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+};

--- a/src/components/MicroChallenge.tsx
+++ b/src/components/MicroChallenge.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { AlertCircle, CheckCircle2, Clock, Volume2 } from "lucide-react";
+import { type MicroChallenge } from "@/data/microChallenges";
+import { getPowerUpDefinition } from "@/data/powerUps";
+
+interface MicroChallengeProps {
+  challenge: MicroChallenge;
+  onFinish: (result: { success: boolean; stars: number; powerUpId: string | null }) => void;
+  simpleMode: boolean;
+  enableSpeech?: boolean;
+}
+
+const speak = (text: string) => {
+  if (typeof window === "undefined" || !("speechSynthesis" in window)) return;
+  const utterance = new SpeechSynthesisUtterance(text);
+  utterance.rate = 0.95;
+  window.speechSynthesis.cancel();
+  window.speechSynthesis.speak(utterance);
+};
+
+export const MicroChallengeCard = ({ challenge, onFinish, simpleMode, enableSpeech = true }: MicroChallengeProps) => {
+  const [timeLeft, setTimeLeft] = useState(challenge.timeLimitSeconds);
+  const [selected, setSelected] = useState<number | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+  const [celebrating, setCelebrating] = useState(false);
+
+  const powerUp = useMemo(() => (challenge.powerUpReward ? getPowerUpDefinition(challenge.powerUpReward) : null), [challenge]);
+  const success = submitted && selected === challenge.correctAnswer;
+
+  useEffect(() => {
+    if (!enableSpeech) return;
+    speak(`${challenge.prompt}. ${challenge.funTip}`);
+  }, [challenge, enableSpeech]);
+
+  useEffect(() => {
+    if (submitted) return;
+    if (timeLeft <= 0) {
+      onFinish({ success: false, stars: 0, powerUpId: null });
+      return;
+    }
+
+    const timer = setTimeout(() => setTimeLeft(prev => prev - 1), 1000);
+    return () => clearTimeout(timer);
+  }, [timeLeft, submitted, onFinish]);
+
+  const handleSubmit = () => {
+    if (selected === null) return;
+    setSubmitted(true);
+    if (selected === challenge.correctAnswer) {
+      setCelebrating(true);
+      setTimeout(() => {
+        setCelebrating(false);
+        onFinish({ success: true, stars: challenge.starReward, powerUpId: challenge.powerUpReward });
+      }, 1600);
+    } else {
+      setTimeout(() => onFinish({ success: false, stars: 0, powerUpId: null }), 1200);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-fuchsia-600 via-purple-600 to-indigo-600 p-4 flex items-center justify-center">
+      <Card className="w-full max-w-3xl bg-white/95 backdrop-blur shadow-2xl p-6 space-y-6">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Clock className="h-6 w-6 text-indigo-500" />
+            <div>
+              <p className="text-xs uppercase tracking-wider text-indigo-600">{simpleMode ? "Speed Round" : "60 Second Micro-Challenge"}</p>
+              <h2 className="text-2xl font-bold text-slate-900">{challenge.prompt}</h2>
+            </div>
+          </div>
+          {enableSpeech && (
+            <Button variant="ghost" size="icon" onClick={() => speak(challenge.prompt)}>
+              <Volume2 className="h-5 w-5" />
+            </Button>
+          )}
+        </div>
+
+        <div>
+          <Progress value={(timeLeft / challenge.timeLimitSeconds) * 100} className="h-2 bg-slate-200" />
+          <div className="flex justify-between text-sm text-slate-600 mt-1">
+            <span>{timeLeft}s left</span>
+            {powerUp && (
+              <span>
+                Reward: {powerUp.icon} {powerUp.name} + {challenge.starReward} ⭐
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="grid gap-3">
+          {challenge.options.map((option, index) => {
+            const isCorrect = submitted && index === challenge.correctAnswer;
+            const isWrong = submitted && selected === index && !isCorrect;
+            return (
+              <Button
+                key={option}
+                variant={selected === index ? "default" : "outline"}
+                className={`justify-start h-auto py-4 px-5 text-left text-base transition-all ${
+                  isCorrect ? "bg-emerald-100 text-emerald-700 border-emerald-200" : ""
+                } ${isWrong ? "bg-red-100 text-red-700 border-red-200" : ""}`}
+                onClick={() => !submitted && setSelected(index)}
+                disabled={submitted}
+              >
+                <span className="flex-1">{option}</span>
+                {isCorrect && <CheckCircle2 className="ml-2 h-5 w-5" />}
+                {isWrong && <AlertCircle className="ml-2 h-5 w-5" />}
+              </Button>
+            );
+          })}
+        </div>
+
+        {!submitted ? (
+          <Button onClick={handleSubmit} disabled={selected === null} size="lg" className="w-full bg-gradient-to-r from-purple-500 to-indigo-500 text-white">
+            {simpleMode ? "Check Answer" : "Lock in answer"}
+          </Button>
+        ) : success ? (
+          <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-emerald-700 flex items-center gap-3">
+            <CheckCircle2 className="h-6 w-6" />
+            <div>
+              <p className="font-semibold">{simpleMode ? "Great job!" : "Micro-challenge mastered!"}</p>
+              <p className="text-sm">{challenge.explanation}</p>
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-2xl border border-red-200 bg-red-50 p-4 text-red-700 flex items-center gap-3">
+            <AlertCircle className="h-6 w-6" />
+            <div>
+              <p className="font-semibold">{simpleMode ? "Let's review" : "So close!"}</p>
+              <p className="text-sm">{challenge.explanation}</p>
+            </div>
+          </div>
+        )}
+
+        {celebrating && (
+          <div className="fixed inset-0 bg-black/20 flex items-center justify-center">
+            <div className="bg-white rounded-3xl p-10 shadow-2xl text-center space-y-2 animate-bounce-soft">
+              <p className="text-4xl">🎉</p>
+              <p className="text-xl font-bold">Stars +{challenge.starReward}</p>
+              {powerUp && <p className="text-sm">Unlocked {powerUp.icon} {powerUp.name}</p>}
+            </div>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+};

--- a/src/components/ParentTeacherView.tsx
+++ b/src/components/ParentTeacherView.tsx
@@ -1,0 +1,156 @@
+import { useMemo, useState } from "react";
+import { ArrowLeft, Clock3, FileText, Users } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { educationalTopics } from "@/data/educationalContent";
+import { type UserProgress } from "@/types/userProgress";
+
+interface ParentTeacherViewProps {
+  onBack: () => void;
+  progress: UserProgress;
+  simpleMode: boolean;
+}
+
+const buildWorksheet = (topicId: number, count = 10) => {
+  const topic = educationalTopics.find(item => item.id === topicId);
+  if (!topic) return [];
+  const baseQuestions = topic.assessmentQuestions ?? [];
+  const questions: string[] = [];
+  let index = 0;
+  while (questions.length < count) {
+    if (baseQuestions[index]) {
+      questions.push(baseQuestions[index].question);
+    } else {
+      questions.push(`${topic.title}: ${topic.question}`);
+    }
+    index = (index + 1) % Math.max(baseQuestions.length, 1);
+    if (baseQuestions.length === 0 && questions.length >= count) break;
+  }
+  return questions;
+};
+
+export const ParentTeacherView = ({ onBack, progress, simpleMode }: ParentTeacherViewProps) => {
+  const [selectedWorksheetTopic, setSelectedWorksheetTopic] = useState<number | null>(null);
+
+  const totalMinutes = progress.totalLearningMinutes ?? 0;
+  const lastSession = progress.lastSessionDate ? new Date(progress.lastSessionDate) : null;
+
+  const weakTopics = useMemo(() => {
+    const attempts = progress.quizAttempts.slice(-10);
+    const aggregated = new Map<number, { scores: number[] }>();
+    attempts.forEach(attempt => {
+      if (!aggregated.has(attempt.topicId)) {
+        aggregated.set(attempt.topicId, { scores: [] });
+      }
+      aggregated.get(attempt.topicId)!.scores.push(attempt.score);
+    });
+    return Array.from(aggregated.entries())
+      .map(([topicId, data]) => ({
+        topicId,
+        average: data.scores.reduce((sum, value) => sum + value, 0) / data.scores.length,
+      }))
+      .filter(item => item.average < 70)
+      .sort((a, b) => a.average - b.average)
+      .slice(0, 3);
+  }, [progress.quizAttempts]);
+
+  const masterySummary = progress.masteryLevels.reduce((acc, mastery) => {
+    acc[mastery.level] = (acc[mastery.level] ?? 0) + 1;
+    return acc;
+  }, {} as Record<string, number>);
+
+  const worksheetQuestions = selectedWorksheetTopic ? buildWorksheet(selectedWorksheetTopic) : [];
+
+  return (
+    <div className="min-h-screen bg-slate-100 p-4 md:p-8">
+      <div className="max-w-5xl mx-auto space-y-6">
+        <Button variant="ghost" onClick={onBack}>
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          {simpleMode ? "Back" : "Back to dashboard"}
+        </Button>
+
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-slate-900">{simpleMode ? "Grown-up View" : "Parent & Teacher View"}</h1>
+            <p className="text-slate-600">
+              {simpleMode
+                ? "Peek at progress, stickers, and practice ideas."
+                : "Quick snapshot of mastered concepts, time on task, and printable practice sets for focus areas."}
+            </p>
+          </div>
+          <Badge variant="secondary" className="bg-emerald-100 text-emerald-800 border-emerald-200">
+            <Users className="h-3 w-3 mr-1" /> Support crew ready
+          </Badge>
+        </div>
+
+        <div className="grid md:grid-cols-3 gap-4">
+          <Card className="p-4 bg-white shadow-sm border border-slate-200">
+            <h2 className="text-sm font-semibold text-slate-500 uppercase">Mastered Concepts</h2>
+            <p className="text-3xl font-bold text-slate-900 mt-1">{progress.topicsCompleted.length}</p>
+            <p className="text-xs text-slate-500 mt-2">Advanced badges: {masterySummary["advanced"] ?? 0} • Mastered: {masterySummary["mastered"] ?? 0}</p>
+          </Card>
+          <Card className="p-4 bg-white shadow-sm border border-slate-200">
+            <h2 className="text-sm font-semibold text-slate-500 uppercase">Time on Task</h2>
+            <p className="text-3xl font-bold text-slate-900 mt-1">{totalMinutes} mins</p>
+            <p className="text-xs text-slate-500 mt-2 flex items-center gap-1">
+              <Clock3 className="h-3 w-3" />
+              {lastSession ? `Last session: ${lastSession.toLocaleDateString()}` : "No sessions yet"}
+            </p>
+          </Card>
+          <Card className="p-4 bg-white shadow-sm border border-slate-200">
+            <h2 className="text-sm font-semibold text-slate-500 uppercase">Current streak</h2>
+            <p className="text-3xl font-bold text-slate-900 mt-1">{progress.streak.dailyCount} days</p>
+            <p className="text-xs text-slate-500 mt-2">Catch-up tokens left: {progress.streak.catchUpTokens}</p>
+          </Card>
+        </div>
+
+        <Card className="p-5 bg-white shadow-sm border border-slate-200">
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+            <div>
+              <h2 className="text-xl font-semibold text-slate-900">{simpleMode ? "Quick practice" : "Printable practice sets"}</h2>
+              <p className="text-sm text-slate-600">{simpleMode ? "Pick a topic to get 10 questions." : "Focus on areas needing extra love. Click a set to print or share."}</p>
+            </div>
+            <Button variant="outline" onClick={() => window.print()}>
+              <FileText className="mr-2 h-4 w-4" /> Print view
+            </Button>
+          </div>
+
+          <div className="mt-4 grid md:grid-cols-3 gap-3">
+            {weakTopics.length === 0 && (
+              <p className="text-sm text-slate-500 col-span-full">Great news! Recent quizzes look strong. Pick any chapter to keep practicing.</p>
+            )}
+            {weakTopics.map(item => {
+              const topic = educationalTopics.find(entry => entry.id === item.topicId);
+              if (!topic) return null;
+              return (
+                <Button
+                  key={topic.id}
+                  variant={selectedWorksheetTopic === topic.id ? "default" : "outline"}
+                  className="justify-start h-auto py-4 px-4 text-left"
+                  onClick={() => setSelectedWorksheetTopic(topic.id)}
+                >
+                  <div>
+                    <p className="font-semibold text-slate-900">{topic.title}</p>
+                    <p className="text-xs text-slate-500">Avg score {item.average.toFixed(0)}%</p>
+                  </div>
+                </Button>
+              );
+            })}
+          </div>
+
+          {worksheetQuestions.length > 0 && (
+            <div className="mt-5 space-y-2">
+              <h3 className="text-lg font-semibold text-slate-900">10-question practice set</h3>
+              <ol className="list-decimal ml-5 space-y-1 text-sm text-slate-700">
+                {worksheetQuestions.map((question, index) => (
+                  <li key={`${question}-${index}`}>{question}</li>
+                ))}
+              </ol>
+            </div>
+          )}
+        </Card>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ProgressDashboard.tsx
+++ b/src/components/ProgressDashboard.tsx
@@ -2,21 +2,24 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
-import { ArrowLeft, Trophy, Target, TrendingUp, BookOpen, Star } from "lucide-react";
+import { ArrowLeft, Trophy, Target, TrendingUp, BookOpen, Star, Award, Flame } from "lucide-react";
 import { getStoredProgress } from "@/utils/progressStorage";
 import { educationalTopics } from "@/data/educationalContent";
+import { StickerAlbum } from "./StickerAlbum";
 
 interface ProgressDashboardProps {
   onBack: () => void;
   onReviewTopic: (topicId: number) => void;
+  onOpenParent: () => void;
+  onOpenCreative: () => void;
+  simpleMode: boolean;
 }
 
-export const ProgressDashboard = ({ onBack, onReviewTopic }: ProgressDashboardProps) => {
+export const ProgressDashboard = ({ onBack, onReviewTopic, onOpenParent, onOpenCreative, simpleMode }: ProgressDashboardProps) => {
   const progress = getStoredProgress();
-  
+
   const totalTopics = educationalTopics.length;
   const completedTopics = progress.topicsCompleted.length;
-  const inProgressTopics = progress.topicsInProgress.length;
   const completionRate = (completedTopics / totalTopics) * 100;
 
   const masteredCount = progress.masteryLevels.filter(m => m.level === "mastered").length;
@@ -27,12 +30,10 @@ export const ProgressDashboard = ({ onBack, onReviewTopic }: ProgressDashboardPr
     ? progress.quizAttempts.reduce((sum, quiz) => sum + quiz.score, 0) / totalQuizzes
     : 0;
 
-  // Topics that need review (based on spaced repetition)
   const topicsNeedingReview = progress.nextReviewDate
     .filter(review => new Date(review.date) <= new Date())
     .slice(0, 5);
 
-  // Weak areas (topics with low quiz scores)
   const weakAreas = progress.quizAttempts
     .filter(quiz => quiz.score < 60)
     .reduce((acc, quiz) => {
@@ -48,7 +49,6 @@ export const ProgressDashboard = ({ onBack, onReviewTopic }: ProgressDashboardPr
     .sort((a, b) => a.avgScore - b.avgScore)
     .slice(0, 3);
 
-  // Recent achievements
   const recentlyMastered = progress.masteryLevels
     .filter(m => m.level === "mastered")
     .slice(-5)
@@ -59,10 +59,19 @@ export const ProgressDashboard = ({ onBack, onReviewTopic }: ProgressDashboardPr
       <div className="max-w-6xl mx-auto">
         <Button variant="ghost" onClick={onBack} className="mb-6">
           <ArrowLeft className="mr-2 h-4 w-4" />
-          Back to Home
+          {simpleMode ? "Back" : "Back to Home"}
         </Button>
 
-        <h1 className="text-4xl font-bold mb-8">Your Learning Progress</h1>
+        <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 mb-8">
+          <div>
+            <h1 className="text-4xl font-bold">{simpleMode ? "My Progress" : "Your Learning Progress"}</h1>
+            <p className="text-muted-foreground">{simpleMode ? "Stars, stickers, and streaks" : "Track concepts, badges, and streaks across Snake Scholars Quest."}</p>
+          </div>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={onOpenParent}>👪 {simpleMode ? "Grown-ups" : "Parent View"}</Button>
+            <Button variant="outline" onClick={onOpenCreative}>🎨 {simpleMode ? "Snake skins" : "Creative Studio"}</Button>
+          </div>
+        </div>
 
         <div className="grid md:grid-cols-3 gap-6 mb-8">
           <Card className="p-6">
@@ -106,6 +115,39 @@ export const ProgressDashboard = ({ onBack, onReviewTopic }: ProgressDashboardPr
           </Card>
         </div>
 
+        <div className="grid md:grid-cols-3 gap-4 mb-8">
+          <Card className="p-4">
+            <div className="flex items-center gap-3 mb-3">
+              <Flame className="w-6 h-6 text-orange-500" />
+              <div>
+                <p className="text-sm text-muted-foreground">Daily streak</p>
+                <p className="text-2xl font-bold">{progress.streak.dailyCount} days</p>
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground">Catch-up tokens left: {progress.streak.catchUpTokens}</p>
+          </Card>
+          <Card className="p-4">
+            <div className="flex items-center gap-3 mb-3">
+              <Award className="w-6 h-6 text-amber-500" />
+              <div>
+                <p className="text-sm text-muted-foreground">Stars collected</p>
+                <p className="text-2xl font-bold">{progress.stars}</p>
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground">Spend stars on power-ups and custom skins.</p>
+          </Card>
+          <Card className="p-4">
+            <div className="flex items-center gap-3 mb-3">
+              <TrendingUp className="w-6 h-6 text-primary" />
+              <div>
+                <p className="text-sm text-muted-foreground">Time on task</p>
+                <p className="text-2xl font-bold">{progress.totalLearningMinutes} mins</p>
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground">Last session: {progress.lastSessionDate ? new Date(progress.lastSessionDate).toLocaleDateString() : "—"}</p>
+          </Card>
+        </div>
+
         {topicsNeedingReview.length > 0 && (
           <Card className="p-6 mb-6">
             <div className="flex items-center gap-2 mb-4">
@@ -113,7 +155,7 @@ export const ProgressDashboard = ({ onBack, onReviewTopic }: ProgressDashboardPr
               <h2 className="text-2xl font-bold">Due for Review</h2>
             </div>
             <p className="text-muted-foreground mb-4">
-              These topics are ready for review based on spaced repetition
+              {simpleMode ? "Ready for a quick refresh" : "These topics are ready for review based on spaced repetition"}
             </p>
             <div className="space-y-2">
               {topicsNeedingReview.map(review => {
@@ -126,7 +168,7 @@ export const ProgressDashboard = ({ onBack, onReviewTopic }: ProgressDashboardPr
                       <p className="text-sm text-muted-foreground">{topic.subject}</p>
                     </div>
                     <Button size="sm" onClick={() => onReviewTopic(review.topicId)}>
-                      Review Now
+                      {simpleMode ? "Play" : "Review Now"}
                     </Button>
                   </div>
                 );
@@ -135,6 +177,11 @@ export const ProgressDashboard = ({ onBack, onReviewTopic }: ProgressDashboardPr
           </Card>
         )}
 
+        <div className="mb-8">
+          <h2 className="text-2xl font-bold mb-4">Sticker Album</h2>
+          <StickerAlbum stickers={progress.stickerAlbum} simpleMode={simpleMode} />
+        </div>
+
         {weakAreas.length > 0 && (
           <Card className="p-6 mb-6">
             <div className="flex items-center gap-2 mb-4">
@@ -142,7 +189,7 @@ export const ProgressDashboard = ({ onBack, onReviewTopic }: ProgressDashboardPr
               <h2 className="text-2xl font-bold">Areas to Improve</h2>
             </div>
             <p className="text-muted-foreground mb-4">
-              Focus on these topics to boost your understanding
+              {simpleMode ? "Practice these again" : "Focus on these topics to boost your understanding"}
             </p>
             <div className="space-y-2">
               {weakAreas.map(area => {
@@ -158,7 +205,7 @@ export const ProgressDashboard = ({ onBack, onReviewTopic }: ProgressDashboardPr
                       </div>
                     </div>
                     <Button size="sm" variant="outline" onClick={() => onReviewTopic(area.topicId)} className="ml-4">
-                      Practice
+                      {simpleMode ? "Practice" : "Practice"}
                     </Button>
                   </div>
                 );
@@ -171,7 +218,7 @@ export const ProgressDashboard = ({ onBack, onReviewTopic }: ProgressDashboardPr
           <Card className="p-6">
             <div className="flex items-center gap-2 mb-4">
               <Star className="w-6 h-6 text-secondary" />
-              <h2 className="text-2xl font-bold">Recently Mastered</h2>
+              <h2 className="text-2xl font-bold">{simpleMode ? "Latest stickers" : "Recently Mastered"}</h2>
             </div>
             <div className="grid md:grid-cols-2 gap-3">
               {recentlyMastered.map(mastery => {

--- a/src/components/QuestMap.tsx
+++ b/src/components/QuestMap.tsx
@@ -1,0 +1,151 @@
+import { useMemo } from "react";
+import { ArrowLeft, Lock, Star } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { questChapters, getChapterIndex, getNextChapterId } from "@/data/questMap";
+import { type ChapterProgress } from "@/types/userProgress";
+
+interface QuestMapProps {
+  onBack: () => void;
+  onOpenChapter: (chapterId: string) => void;
+  chapterProgress: ChapterProgress[];
+  stars: number;
+  simpleMode: boolean;
+}
+
+const getChapterStatus = (chapterId: string, progress: ChapterProgress[]) => {
+  const chapterProgress = progress.find(chapter => chapter.chapterId === chapterId);
+  return {
+    unlocked: chapterProgress?.unlocked ?? getChapterIndex(chapterId) === 0,
+    badgeTier: chapterProgress?.badgeTier ?? 0,
+    completedTopics: chapterProgress?.completedTopicIds?.length ?? 0,
+  };
+};
+
+export const QuestMap = ({ onBack, onOpenChapter, chapterProgress, stars, simpleMode }: QuestMapProps) => {
+  const unlockedChapters = useMemo(() => new Set(
+    chapterProgress.filter(chapter => chapter.unlocked).map(chapter => chapter.chapterId),
+  ), [chapterProgress]);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white p-4 md:p-8">
+      <div className="max-w-6xl mx-auto space-y-6">
+        <div className="flex items-center justify-between">
+          <Button variant="ghost" onClick={onBack} className="text-white/80 hover:text-white">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            {simpleMode ? "Back" : "Back to Modes"}
+          </Button>
+          <div className="flex items-center gap-2 bg-amber-400/20 text-amber-200 px-4 py-2 rounded-full">
+            <Star className="h-4 w-4" />
+            <span className="font-semibold">{stars} {simpleMode ? "Stars" : "Shiny Stars"}</span>
+          </div>
+        </div>
+
+        <div className="text-center space-y-3">
+          <h1 className="text-4xl md:text-5xl font-extrabold tracking-tight">
+            {simpleMode ? "Adventure Map" : "Quest Map: Snake Scholars World"}
+          </h1>
+          <p className="text-lg text-white/80 max-w-2xl mx-auto">
+            {simpleMode
+              ? "Choose a land to explore. Unlock new zones by acing chapter quizzes!"
+              : "Travel through math biomes! Unlock each chapter by answering 2 of 3 questions correctly, earn stars, and power up your snake."}
+          </p>
+        </div>
+
+        <div className="relative w-full h-[540px] bg-gradient-to-br from-slate-800 to-slate-900 rounded-3xl border border-white/10 overflow-hidden shadow-2xl">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(148,163,184,0.15),_transparent_60%)]" />
+          <div className="absolute inset-0 pointer-events-none select-none opacity-40">
+            <svg viewBox="0 0 100 100" className="w-full h-full">
+              <defs>
+                <radialGradient id="node" cx="0.5" cy="0.5" r="0.5">
+                  <stop offset="0%" stopColor="rgba(255,255,255,0.9)" />
+                  <stop offset="100%" stopColor="rgba(100,116,139,0)" />
+                </radialGradient>
+              </defs>
+              <line x1="15" y1="70" x2="35" y2="45" stroke="rgba(148,163,184,0.4)" strokeWidth="1" strokeDasharray="4 2" />
+              <line x1="35" y1="45" x2="58" y2="60" stroke="rgba(148,163,184,0.4)" strokeWidth="1" strokeDasharray="4 2" />
+              <line x1="58" y1="60" x2="75" y2="40" stroke="rgba(148,163,184,0.4)" strokeWidth="1" strokeDasharray="4 2" />
+              <line x1="35" y1="45" x2="22" y2="25" stroke="rgba(148,163,184,0.4)" strokeWidth="1" strokeDasharray="4 2" />
+              <line x1="58" y1="60" x2="88" y2="72" stroke="rgba(148,163,184,0.4)" strokeWidth="1" strokeDasharray="4 2" />
+            </svg>
+          </div>
+
+          {questChapters.map(chapter => {
+            const status = getChapterStatus(chapter.id, chapterProgress);
+            const unlocked = status.unlocked || unlockedChapters.has(chapter.id) || getChapterIndex(chapter.id) === 0;
+            return (
+              <button
+                key={chapter.id}
+                type="button"
+                onClick={() => unlocked && onOpenChapter(chapter.id)}
+                disabled={!unlocked}
+                className={`absolute transform -translate-x-1/2 -translate-y-1/2 transition-all duration-300 ${
+                  unlocked
+                    ? "hover:scale-105 focus-visible:scale-105"
+                    : "opacity-60 cursor-not-allowed"
+                }`}
+                style={{ left: `${chapter.mapPosition.x}%`, top: `${chapter.mapPosition.y}%` }}
+              >
+                <div className={`w-40 md:w-48 bg-gradient-to-br ${chapter.color} rounded-2xl p-4 shadow-xl border border-white/20`}> 
+                  <div className="flex items-center justify-between">
+                    <span className="text-2xl" aria-hidden>{chapter.icon}</span>
+                    <Badge variant="secondary" className="bg-white/20 text-white border-white/30">
+                      {status.badgeTier > 0 ? `${status.badgeTier}/3` : "0/3"}
+                    </Badge>
+                  </div>
+                  <h2 className="mt-2 text-lg font-bold leading-tight">{chapter.title}</h2>
+                  <p className="text-xs text-white/80 mt-1 line-clamp-3">{chapter.description}</p>
+                  <div className="mt-3 flex items-center justify-between text-xs text-white/70">
+                    <span>{status.completedTopics} / {chapter.topicIds.length} topics</span>
+                    {!unlocked && (
+                      <span className="flex items-center gap-1">
+                        <Lock className="h-3 w-3" />
+                        {simpleMode ? "Locked" : "Pass quiz"}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="grid md:grid-cols-3 gap-4">
+          {questChapters.map(chapter => {
+            const status = getChapterStatus(chapter.id, chapterProgress);
+            const nextChapterId = getNextChapterId(chapter.id);
+            const lockedMessage = nextChapterId
+              ? `Unlock by passing the ${chapter.title} chapter quiz.`
+              : "Master all chapters to earn the Legend badge!";
+            return (
+              <Card key={chapter.id} className="bg-slate-900/70 border-white/10 text-white p-5 space-y-3">
+                <div className="flex items-center gap-3">
+                  <span className="text-2xl" aria-hidden>{chapter.icon}</span>
+                  <div>
+                    <p className="text-sm uppercase tracking-wide text-white/60">{chapter.nickname}</p>
+                    <h3 className="text-xl font-semibold">{chapter.title}</h3>
+                  </div>
+                </div>
+                <p className="text-sm text-white/75">{chapter.funFact}</p>
+                <div className="flex items-center gap-2 text-xs text-white/60">
+                  <Badge variant="outline" className="border-white/20 text-white/80">
+                    {status.completedTopics} / {chapter.topicIds.length} {simpleMode ? "lessons" : "quests"}
+                  </Badge>
+                  <Badge variant="outline" className="border-white/20 text-white/80">
+                    Tier {status.badgeTier} badge
+                  </Badge>
+                </div>
+                {!status.unlocked && getChapterIndex(chapter.id) !== 0 && (
+                  <p className="text-xs text-amber-200 bg-amber-500/10 border border-amber-500/30 rounded-md p-2">
+                    {lockedMessage}
+                  </p>
+                )}
+              </Card>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -9,12 +9,32 @@ interface StartScreenProps {
   onViewTopics: () => void;
   onViewFounders: () => void;
   onViewProgress: () => void;
+  onViewParent: () => void;
+  onViewLeaderboard: () => void;
+  onOpenCreative: () => void;
+  onToggleSimpleMode: () => void;
+  onToggleSpeech: () => void;
+  simpleMode: boolean;
+  speechEnabled: boolean;
   highScore: number;
 }
 
-export const StartScreen = ({ onStart, onViewTopics, onViewFounders, onViewProgress, highScore }: StartScreenProps) => {
+export const StartScreen = ({
+  onStart,
+  onViewTopics,
+  onViewFounders,
+  onViewProgress,
+  onViewParent,
+  onViewLeaderboard,
+  onOpenCreative,
+  onToggleSimpleMode,
+  onToggleSpeech,
+  simpleMode,
+  speechEnabled,
+  highScore,
+}: StartScreenProps) => {
   const streak = calculateStudyStreak();
-  
+
   return (
     <AccessibilityWrapper pageTitle="Welcome" announcement="Welcome to Snake Scholars Quest">
       <div className="min-h-screen bg-gradient-hero flex items-center justify-center p-4 overflow-hidden">
@@ -29,15 +49,17 @@ export const StartScreen = ({ onStart, onViewTopics, onViewFounders, onViewProgr
         </div>
 
         <h1 className="text-5xl md:text-7xl font-bold text-background mb-4 animate-slide-up" style={{ animationDelay: "0.1s" }}>
-          Snake Runner
+          {simpleMode ? "Snake Quest" : "Snake Runner"}
         </h1>
-        
+
         <p className="text-xl md:text-2xl text-background/90 mb-2 animate-slide-up" style={{ animationDelay: "0.2s" }}>
-          Learn Math & Science While You Run!
+          {simpleMode ? "Play. Learn. Level up." : "Learn Math & Science While You Run!"}
         </p>
-        
+
         <p className="text-lg text-background/80 mb-10 max-w-xl mx-auto animate-slide-up" style={{ animationDelay: "0.3s" }}>
-          Swipe to move lanes, collect insects, avoid obstacles, and discover amazing science & math concepts!
+          {simpleMode
+            ? "Unlock lands, collect stickers, and power up your snake with math moves."
+            : "Swipe to move lanes, collect insects, avoid obstacles, and discover amazing science & math concepts!"}
         </p>
 
         {highScore > 0 && (
@@ -59,8 +81,8 @@ export const StartScreen = ({ onStart, onViewTopics, onViewFounders, onViewProgr
         )}
 
         <div className="flex flex-col sm:flex-row gap-4 justify-center animate-slide-up mb-8" style={{ animationDelay: "0.5s" }}>
-          <Button 
-            size="lg" 
+          <Button
+            size="lg"
             variant="hero"
             onClick={onStart}
             className="group animate-pulse-glow text-lg"
@@ -86,6 +108,18 @@ export const StartScreen = ({ onStart, onViewTopics, onViewFounders, onViewProgr
           </Button>
         </div>
 
+        <div className="flex flex-wrap justify-center gap-3 animate-fade-in" style={{ animationDelay: "0.55s" }}>
+          <Button size="sm" variant="heroOutline" onClick={onOpenCreative}>
+            🎨 Creative Studio
+          </Button>
+          <Button size="sm" variant="heroOutline" onClick={onViewLeaderboard}>
+            🏅 Leaderboard
+          </Button>
+          <Button size="sm" variant="heroOutline" onClick={onViewParent}>
+            👪 Parent View
+          </Button>
+        </div>
+
         <div className="mt-12 grid grid-cols-3 gap-4 max-w-lg mx-auto animate-slide-up" style={{ animationDelay: "0.6s" }}>
           <div className="bg-background/10 backdrop-blur-sm border border-background/20 rounded-xl p-4">
             <div className="text-3xl mb-1">➕</div>
@@ -106,13 +140,22 @@ export const StartScreen = ({ onStart, onViewTopics, onViewFounders, onViewProgr
         </div>
 
         <div className="mt-6 animate-slide-up" style={{ animationDelay: "0.8s" }}>
-          <Button 
+          <Button
             variant="ghost"
             onClick={onViewFounders}
             className="text-background/90 hover:text-background hover:bg-background/10"
           >
             <Users className="mr-2 h-4 w-4" />
             Meet the Founders
+          </Button>
+        </div>
+
+        <div className="mt-6 flex flex-wrap justify-center gap-3 text-sm text-background/80 animate-slide-up" style={{ animationDelay: "0.85s" }}>
+          <Button variant="ghost" size="sm" onClick={onToggleSimpleMode}>
+            {simpleMode ? "Switch to Explorer mode" : "Simple words mode"}
+          </Button>
+          <Button variant="ghost" size="sm" onClick={onToggleSpeech}>
+            {speechEnabled ? "Mute voice" : "Turn on read aloud"}
           </Button>
         </div>
         </div>

--- a/src/components/StickerAlbum.tsx
+++ b/src/components/StickerAlbum.tsx
@@ -1,0 +1,64 @@
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { educationalTopics } from "@/data/educationalContent";
+import { type StickerAlbumEntry } from "@/types/userProgress";
+
+interface StickerAlbumProps {
+  stickers: StickerAlbumEntry[];
+  simpleMode: boolean;
+}
+
+const getTierLabel = (tier: number) => {
+  switch (tier) {
+    case 1:
+      return "Bronze";
+    case 2:
+      return "Silver";
+    case 3:
+      return "Gold";
+    default:
+      return "Starter";
+  }
+};
+
+export const StickerAlbum = ({ stickers, simpleMode }: StickerAlbumProps) => {
+  const stickerMap = new Map(stickers.map(sticker => [sticker.topicId, sticker]));
+
+  return (
+    <div className="grid md:grid-cols-3 gap-4">
+      {educationalTopics.filter(topic => topic.subject === "math").map(topic => {
+        const entry = stickerMap.get(topic.id);
+        const tiers = entry?.tiersUnlocked ?? [];
+        const highestTier = tiers.length > 0 ? Math.max(...tiers) : 0;
+        return (
+          <Card key={topic.id} className="p-4 bg-gradient-to-br from-white via-slate-50 to-emerald-50 border-emerald-200/30">
+            <div className="flex items-center gap-3 mb-2">
+              <span className="text-2xl" aria-hidden>{topic.emoji}</span>
+              <div>
+                <h3 className="font-semibold text-slate-900">{topic.title}</h3>
+                <p className="text-xs text-slate-500">{simpleMode ? "Sticker" : "Concept sticker"}</p>
+              </div>
+            </div>
+            <p className="text-sm text-slate-600 mb-3 line-clamp-2">{topic.learningOutcome}</p>
+            <div className="flex flex-wrap gap-2">
+              {[1, 2, 3].map(tier => (
+                <Badge
+                  key={tier}
+                  variant={tiers.includes(tier) ? "default" : "outline"}
+                  className={tiers.includes(tier) ? "bg-emerald-500 text-white" : "text-slate-500"}
+                >
+                  {getTierLabel(tier)}
+                </Badge>
+              ))}
+            </div>
+            <div className="mt-3 text-xs text-emerald-700">
+              {highestTier > 0
+                ? `${getTierLabel(highestTier)} badge earned!`
+                : "Answer chapter quizzes to unlock shiny stickers."}
+            </div>
+          </Card>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/TopicSelector.tsx
+++ b/src/components/TopicSelector.tsx
@@ -11,7 +11,11 @@ import { Badge } from "@/components/ui/badge";
 interface TopicSelectorProps {
   onSelectTopic: (topicId: number) => void;
   onBack: () => void;
+  onBackToMap?: () => void;
   mode: "study" | "practice" | "challenge";
+  availableTopicIds?: number[];
+  chapterTitle?: string;
+  simpleMode: boolean;
 }
 
 const subjectColors: Record<string, string> = {
@@ -24,12 +28,16 @@ const subjectColors: Record<string, string> = {
   programming: "text-indigo-600 bg-indigo-50 dark:bg-indigo-950/50",
 };
 
-export const TopicSelector = ({ onSelectTopic, onBack, mode }: TopicSelectorProps) => {
+export const TopicSelector = ({ onSelectTopic, onBack, onBackToMap, mode, availableTopicIds, chapterTitle, simpleMode }: TopicSelectorProps) => {
   const [selectedSubject, setSelectedSubject] = useState("all");
 
+  const topicsPool = availableTopicIds && availableTopicIds.length > 0
+    ? educationalTopics.filter(topic => availableTopicIds.includes(topic.id))
+    : educationalTopics;
+
   const filteredTopics = selectedSubject === "all"
-    ? educationalTopics
-    : educationalTopics.filter(topic => topic.subject === selectedSubject);
+    ? topicsPool
+    : topicsPool.filter(topic => topic.subject === selectedSubject);
 
   const getMasteryBadge = (topicId: number) => {
     const mastery = getMasteryLevel(topicId);
@@ -48,32 +56,49 @@ export const TopicSelector = ({ onSelectTopic, onBack, mode }: TopicSelectorProp
   return (
     <div className="min-h-screen bg-background p-4 md:p-8">
       <div className="max-w-7xl mx-auto">
-        <Button
-          variant="ghost"
-          onClick={onBack}
-          className="mb-6"
-        >
-          <ArrowLeft className="mr-2 h-4 w-4" />
-          Back to Modes
-        </Button>
+        <div className="flex flex-wrap items-center gap-3 mb-6">
+          <Button
+            variant="ghost"
+            onClick={onBack}
+          >
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            {simpleMode ? "Back" : "Back to Modes"}
+          </Button>
+          {onBackToMap && (
+            <Button variant="ghost" onClick={onBackToMap}>
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              {simpleMode ? "Quest map" : "Back to quest map"}
+            </Button>
+          )}
+        </div>
 
         <div className="text-center mb-8">
-          <h1 className="text-4xl font-bold mb-3">Select a Topic to Learn</h1>
+          <h1 className="text-4xl font-bold mb-3">{chapterTitle ? `${chapterTitle} Lessons` : "Select a Topic to Learn"}</h1>
           <p className="text-xl text-muted-foreground">
-            {mode === "study" && "Choose any topic to start learning"}
-            {mode === "practice" && "Complete the lesson, then play the game"}
-            {mode === "challenge" && "Advanced mixed-topic challenges"}
+            {simpleMode
+              ? "Pick a card to explore. Pass the quiz to earn stickers!"
+              : (
+                <>
+                  {mode === "study" && "Choose any topic to start learning"}
+                  {mode === "practice" && "Complete the lesson, then play the game"}
+                  {mode === "challenge" && "Advanced mixed-topic challenges"}
+                </>
+              )}
           </p>
         </div>
 
-        <SubjectFilter 
-          selectedSubject={selectedSubject}
-          onSubjectChange={setSelectedSubject}
-        />
+        {!availableTopicIds && (
+          <SubjectFilter
+            selectedSubject={selectedSubject}
+            onSubjectChange={setSelectedSubject}
+          />
+        )}
 
-        <div className="mb-6">
-          <LearningRecommendations onSelectTopic={onSelectTopic} />
-        </div>
+        {!availableTopicIds && (
+          <div className="mb-6">
+            <LearningRecommendations onSelectTopic={onSelectTopic} />
+          </div>
+        )}
 
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
           {filteredTopics.map((topic, index) => {

--- a/src/data/microChallenges.ts
+++ b/src/data/microChallenges.ts
@@ -1,0 +1,66 @@
+export interface MicroChallenge {
+  id: string;
+  topicIds: number[];
+  prompt: string;
+  options: string[];
+  correctAnswer: number;
+  explanation: string;
+  starReward: number;
+  powerUpReward: "length-boost" | "angle-shield" | "fraction-freeze" | null;
+  timeLimitSeconds: number;
+  funTip: string;
+}
+
+export const microChallenges: MicroChallenge[] = [
+  {
+    id: "fraction-flash",
+    topicIds: [102, 104],
+    prompt: "The snake stretches 3/5 of a log and a beaver chews 1/5 more. How much of the log is covered now?",
+    options: ["4/5", "3/6", "2/5", "1"],
+    correctAnswer: 0,
+    explanation: "Add fractions with the same denominator: 3/5 + 1/5 = 4/5. The log is almost full!",
+    starReward: 8,
+    powerUpReward: "length-boost",
+    timeLimitSeconds: 45,
+    funTip: "Friendly hint: equal bottoms mean you just add the tops!",
+  },
+  {
+    id: "angle-guardian",
+    topicIds: [14, 9],
+    prompt: "A shield opens to 90°. If the snake twists it 30° more, what angle is the shield now?",
+    options: ["120°", "100°", "60°", "180°"],
+    correctAnswer: 0,
+    explanation: "90° + 30° = 120°. That's an obtuse angle—perfect for blocking obstacles!",
+    starReward: 10,
+    powerUpReward: "angle-shield",
+    timeLimitSeconds: 40,
+    funTip: "Right angles are 90°. Bigger ones are obtuse like a big hug!",
+  },
+  {
+    id: "decimal-dash",
+    topicIds: [5, 13],
+    prompt: "The snake slides 12.5 m then 7.4 m in a speed run. How far altogether?",
+    options: ["19.9 m", "19.8 m", "18.9 m", "20.1 m"],
+    correctAnswer: 0,
+    explanation: "Line up decimals: 12.5 + 7.4 = 19.9 m. Almost twenty meters of speedy math!",
+    starReward: 6,
+    powerUpReward: "fraction-freeze",
+    timeLimitSeconds: 50,
+    funTip: "Keep the decimal points lined up like train doors."
+  },
+  {
+    id: "pattern-pop",
+    topicIds: [8, 15, 103],
+    prompt: "Find the missing number: 4, 9, 14, __, 24",
+    options: ["19", "18", "20", "17"],
+    correctAnswer: 1,
+    explanation: "The pattern adds 5 each time: 4 + 5 = 9, 9 + 5 = 14, 14 + 5 = 19, 19 + 5 = 24!",
+    starReward: 7,
+    powerUpReward: "length-boost",
+    timeLimitSeconds: 35,
+    funTip: "Patterns are like music beats—listen for the repeat!",
+  },
+];
+
+export const getChallengeForTopic = (topicId: number) =>
+  microChallenges.find(challenge => challenge.topicIds.includes(topicId));

--- a/src/data/powerUps.ts
+++ b/src/data/powerUps.ts
@@ -1,0 +1,34 @@
+export interface PowerUpDefinition {
+  id: "length-boost" | "angle-shield" | "fraction-freeze";
+  name: string;
+  description: string;
+  effect: string;
+  icon: string;
+}
+
+export const powerUps: PowerUpDefinition[] = [
+  {
+    id: "length-boost",
+    name: "Length Boost",
+    description: "Grow an extra glowing tail segment that doubles bug points for 30 seconds.",
+    effect: "double-points",
+    icon: "📏",
+  },
+  {
+    id: "angle-shield",
+    name: "Angle Shield",
+    description: "A shimmering protractor shield absorbs one obstacle hit.",
+    effect: "one-hit-guard",
+    icon: "🛡️",
+  },
+  {
+    id: "fraction-freeze",
+    name: "Fraction Freeze",
+    description: "Freeze time to half speed for 10 seconds—perfect for tight squeezes!",
+    effect: "slow-time",
+    icon: "❄️",
+  },
+];
+
+export const getPowerUpDefinition = (id: PowerUpDefinition["id"]) =>
+  powerUps.find(power => power.id === id);

--- a/src/data/questMap.ts
+++ b/src/data/questMap.ts
@@ -1,0 +1,118 @@
+import { educationalTopics } from "./educationalContent";
+
+export interface QuestChapter {
+  id: string;
+  title: string;
+  nickname: string;
+  description: string;
+  icon: string;
+  color: string;
+  theme: "forest" | "grove" | "alley" | "harbor" | "observatory" | "dojo";
+  mapPosition: { x: number; y: number };
+  topicIds: number[];
+  badgeId: string;
+  funFact: string;
+}
+
+export const questChapters: QuestChapter[] = [
+  {
+    id: "fractions-forest",
+    title: "Fractions Forest",
+    nickname: "Friendly Fractions",
+    description: "Turn pizza slices and battery bars into brave math missions!",
+    icon: "🌲",
+    color: "from-emerald-400 to-green-600",
+    theme: "forest",
+    mapPosition: { x: 12, y: 72 },
+    topicIds: [102, 4, 5],
+    badgeId: "fraction-master",
+    funFact: "Butterflies in the forest flap wings in perfect fractions of a second!",
+  },
+  {
+    id: "geometry-grove",
+    title: "Geometry Grove",
+    nickname: "Shape Shifters",
+    description: "Measure playgrounds, angle branches, and build forts with area magic.",
+    icon: "📐",
+    color: "from-blue-400 to-sky-600",
+    theme: "grove",
+    mapPosition: { x: 36, y: 48 },
+    topicIds: [14, 9, 10],
+    badgeId: "area-ace",
+    funFact: "Trees grow in spiral patterns that follow secret geometry rules!",
+  },
+  {
+    id: "algebra-alley",
+    title: "Algebra Alley",
+    nickname: "Puzzle Programmers",
+    description: "Crack patterns, solve for x, and balance equations with street smarts.",
+    icon: "🧩",
+    color: "from-purple-400 to-indigo-600",
+    theme: "alley",
+    mapPosition: { x: 58, y: 62 },
+    topicIds: [103, 15, 7],
+    badgeId: "pattern-pro",
+    funFact: "Street artists hide algebra patterns in murals all over the world!",
+  },
+  {
+    id: "measurement-harbor",
+    title: "Measurement Harbor",
+    nickname: "Captain Measure",
+    description: "Sail through capacity, volume, and time with trusty measuring mates.",
+    icon: "⚓",
+    color: "from-cyan-400 to-blue-500",
+    theme: "harbor",
+    mapPosition: { x: 74, y: 38 },
+    topicIds: [107, 108, 1],
+    badgeId: "measure-mate",
+    funFact: "Harbor clocks use precise angles to guide ships safely home!",
+  },
+  {
+    id: "data-observatory",
+    title: "Data Observatory",
+    nickname: "Chart Champions",
+    description: "Read star charts, tally meteor showers, and decode secret data signals.",
+    icon: "🔭",
+    color: "from-amber-400 to-orange-500",
+    theme: "observatory",
+    mapPosition: { x: 20, y: 24 },
+    topicIds: [13, 8, 6],
+    badgeId: "data-detective",
+    funFact: "Astronomers graph stars to discover brand-new planets!",
+  },
+  {
+    id: "logic-dojo",
+    title: "Logic Dojo",
+    nickname: "Mind Ninjas",
+    description: "Train with quick brain challenges and lightning-round mental math.",
+    icon: "🥋",
+    color: "from-rose-400 to-red-500",
+    theme: "dojo",
+    mapPosition: { x: 88, y: 70 },
+    topicIds: [101, 105, 2],
+    badgeId: "logic-legend",
+    funFact: "Martial artists use patterns and timing—just like algebra and fractions!",
+  },
+];
+
+export const chapterOrder = questChapters.map(chapter => chapter.id);
+
+export const getChapterByTopicId = (topicId: number): QuestChapter | undefined =>
+  questChapters.find(chapter => chapter.topicIds.includes(topicId));
+
+export const getChapterIndex = (chapterId: string) =>
+  chapterOrder.findIndex(id => id === chapterId);
+
+export const getNextChapterId = (chapterId: string) => {
+  const currentIndex = getChapterIndex(chapterId);
+  if (currentIndex < 0) return undefined;
+  return chapterOrder[currentIndex + 1];
+};
+
+export const getChapterTopics = (chapterId: string) => {
+  const chapter = questChapters.find(c => c.id === chapterId);
+  if (!chapter) return [];
+  return chapter.topicIds
+    .map(topicId => educationalTopics.find(topic => topic.id === topicId))
+    .filter((topic): topic is NonNullable<typeof topic> => Boolean(topic));
+};

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 import { StartScreen } from "@/components/StartScreen";
 import { EndlessRunner } from "@/components/EndlessRunner";
 import { TopicReveal } from "@/components/TopicReveal";
@@ -9,68 +10,209 @@ import { TopicSelector } from "@/components/TopicSelector";
 import { InteractiveLesson } from "@/components/InteractiveLesson";
 import { ProgressDashboard } from "@/components/ProgressDashboard";
 import { AssessmentGate } from "@/components/AssessmentGate";
+import { QuestMap } from "@/components/QuestMap";
+import { MicroChallengeCard } from "@/components/MicroChallenge";
+import { LeaderboardPanel } from "@/components/LeaderboardPanel";
+import { CreativeStudio } from "@/components/CreativeStudio";
+import { ParentTeacherView } from "@/components/ParentTeacherView";
 import { LearningMode } from "@/types/userProgress";
-import { hasCompletedLesson } from "@/utils/progressStorage";
-import { educationalTopics } from "@/data/educationalContent";
+import {
+  awardStars,
+  getStoredProgress,
+  grantPowerUp,
+  hasCompletedLesson,
+  recordChapterCompletion,
+  setActiveSkin,
+  spendStars,
+  unlockChapter,
+  unlockCreativeSkin,
+  updateLeaderboardProfile,
+  updateStickerAlbum,
+  updateStreak,
+} from "@/utils/progressStorage";
+import {
+  educationalTopics,
+  type AssessmentQuestion,
+  type EducationalTopic,
+} from "@/data/educationalContent";
+import { generateAssessmentQuestions } from "@/utils/questionBank";
+import {
+  getChapterByTopicId,
+  getChapterTopics,
+  getNextChapterId,
+  questChapters,
+} from "@/data/questMap";
+import { getChallengeForTopic, type MicroChallenge } from "@/data/microChallenges";
 
-type Screen = "start" | "mode-select" | "topic-select" | "assessment" | "lesson" | "game" | "reveal" | "library" | "founders" | "progress";
+type PowerUpId = "length-boost" | "angle-shield" | "fraction-freeze";
+
+type Screen =
+  | "start"
+  | "mode-select"
+  | "quest-map"
+  | "topic-select"
+  | "assessment"
+  | "micro-challenge"
+  | "lesson"
+  | "game"
+  | "reveal"
+  | "library"
+  | "founders"
+  | "progress"
+  | "leaderboard"
+  | "creative"
+  | "parent";
 
 const Index = () => {
   const [screen, setScreen] = useState<Screen>("start");
   const [selectedMode, setSelectedMode] = useState<LearningMode>("practice");
+  const [selectedChapterId, setSelectedChapterId] = useState<string | null>(null);
   const [selectedTopicId, setSelectedTopicId] = useState<number | null>(null);
   const [lastScore, setLastScore] = useState(0);
   const [lastTopicId, setLastTopicId] = useState(1);
   const [highScore, setHighScore] = useState(0);
+  const [assessmentQuestions, setAssessmentQuestions] = useState<AssessmentQuestion[] | null>(null);
+  const [pendingRewards, setPendingRewards] = useState<{ powerUps: PowerUpId[]; stars: number }>({ powerUps: [], stars: 0 });
+  const [sessionPowerUps, setSessionPowerUps] = useState<PowerUpId[]>([]);
+  const [activeChallenge, setActiveChallenge] = useState<MicroChallenge | null>(null);
+  const [simpleMode, setSimpleMode] = useState(false);
+  const [speechEnabled, setSpeechEnabled] = useState(true);
+  const [playerProgress, setPlayerProgress] = useState(getStoredProgress);
+
+  const refreshProgress = () => setPlayerProgress(getStoredProgress());
+
+  useEffect(() => {
+    refreshProgress();
+  }, []);
+
+  const selectedTopic = useMemo(() => {
+    if (selectedTopicId == null) return null;
+    return educationalTopics.find(topic => topic.id === selectedTopicId) ?? null;
+  }, [selectedTopicId]);
+
+  const buildAssessmentQuestions = useCallback(
+    (topic: EducationalTopic): AssessmentQuestion[] =>
+      topic.assessmentQuestions ??
+      generateAssessmentQuestions(
+        topic.id,
+        topic.question,
+        topic.options,
+        topic.correctAnswer,
+        topic.explanation,
+      ),
+    [],
+  );
 
   const handleStart = () => {
+    updateStreak();
+    refreshProgress();
     setScreen("mode-select");
   };
 
   const handleModeSelect = (mode: LearningMode) => {
     setSelectedMode(mode);
+    setScreen("quest-map");
+  };
+
+  const handleOpenChapter = (chapterId: string) => {
+    setSelectedChapterId(chapterId);
     setScreen("topic-select");
   };
 
   const handleTopicSelect = (topicId: number) => {
     setSelectedTopicId(topicId);
-    
-    // Check if lesson is already completed
-    if (hasCompletedLesson(topicId)) {
-      if (selectedMode === "practice") {
-        // Go to assessment gate before game
-        setScreen("assessment");
-      } else {
-        // In study mode, go to lesson
-        setScreen("lesson");
-      }
-    } else {
-      // Show lesson first
-      setScreen("lesson");
-    }
-  };
 
-  const handleAssessmentPass = () => {
-    setScreen("game");
+    const topic = educationalTopics.find(t => t.id === topicId);
+    if (topic) {
+      setAssessmentQuestions(buildAssessmentQuestions(topic));
+    } else {
+      setAssessmentQuestions(null);
+    }
+
+    const lessonCompleted = hasCompletedLesson(topicId);
+    if (lessonCompleted && selectedMode === "practice") {
+      setScreen("assessment");
+      return;
+    }
+
+    setScreen("lesson");
   };
 
   const handleAssessmentRetry = () => {
-    // Generate new shuffled questions and retry
+    if (selectedTopic) {
+      setAssessmentQuestions(buildAssessmentQuestions(selectedTopic));
+    }
     setScreen("assessment");
   };
 
   const handleLessonComplete = () => {
     if (selectedMode === "practice") {
-      // After lesson in practice mode, go to assessment gate
       setScreen("assessment");
     } else {
-      // In study mode, go back to topic selection
-      setScreen("topic-select");
+      setScreen("quest-map");
     }
   };
 
+  const applyRewards = (powerUps: PowerUpId[], stars: number) => {
+    if (powerUps.length > 0) {
+      powerUps.forEach(power => grantPowerUp(power));
+      setSessionPowerUps(powerUps);
+    } else {
+      setSessionPowerUps([]);
+    }
+
+    if (stars > 0) {
+      awardStars(stars);
+    }
+    refreshProgress();
+  };
+
+  const handleAssessmentPass = (result: { correct: number; total: number; stars: number; powerUps: PowerUpId[] }) => {
+    if (!selectedTopic) return;
+
+    const chapter = getChapterByTopicId(selectedTopic.id);
+    if (chapter) {
+      recordChapterCompletion(chapter.id, selectedTopic.id);
+      if (result.correct >= 2) {
+        const nextChapterId = getNextChapterId(chapter.id);
+        if (nextChapterId) {
+          unlockChapter(nextChapterId);
+        }
+      }
+    }
+
+    const tier = result.correct === result.total ? 3 : result.correct === result.total - 1 ? 2 : 1;
+    updateStickerAlbum(selectedTopic.id, tier);
+
+    setPendingRewards({ powerUps: result.powerUps, stars: result.stars });
+
+    const challenge = getChallengeForTopic(selectedTopic.id);
+    if (challenge) {
+      setActiveChallenge(challenge);
+      setScreen("micro-challenge");
+    } else {
+      applyRewards(result.powerUps, result.stars);
+      setPendingRewards({ powerUps: [], stars: 0 });
+      setScreen("game");
+    }
+
+    refreshProgress();
+  };
+
+  const handleMicroChallengeFinish = (outcome: { success: boolean; stars: number; powerUpId: string | null }) => {
+    const rewardPowerUps = [...pendingRewards.powerUps];
+    if (outcome.success && outcome.powerUpId) {
+      rewardPowerUps.push(outcome.powerUpId as PowerUpId);
+    }
+    const totalStars = pendingRewards.stars + (outcome.success ? outcome.stars : 0);
+    applyRewards(rewardPowerUps, totalStars);
+    setPendingRewards({ powerUps: [], stars: 0 });
+    setActiveChallenge(null);
+    setScreen("game");
+  };
+
   const handleViewTopics = () => {
-    setScreen("library");
+    setScreen("quest-map");
   };
 
   const handleViewFounders = () => {
@@ -78,7 +220,23 @@ const Index = () => {
   };
 
   const handleViewProgress = () => {
+    refreshProgress();
     setScreen("progress");
+  };
+
+  const handleViewLeaderboard = () => {
+    refreshProgress();
+    setScreen("leaderboard");
+  };
+
+  const handleOpenParent = () => {
+    refreshProgress();
+    setScreen("parent");
+  };
+
+  const handleOpenCreative = () => {
+    refreshProgress();
+    setScreen("creative");
   };
 
   const handleReviewTopic = (topicId: number) => {
@@ -89,14 +247,16 @@ const Index = () => {
   const handleBackToStart = () => {
     setScreen("start");
     setSelectedTopicId(null);
+    setAssessmentQuestions(null);
+    setSessionPowerUps([]);
   };
 
   const handleBackToModes = () => {
     setScreen("mode-select");
   };
 
-  const handleBackToTopics = () => {
-    setScreen("topic-select");
+  const handleBackToQuestMap = () => {
+    setScreen("quest-map");
   };
 
   const handleGameOver = (score: number, topicId: number) => {
@@ -105,12 +265,51 @@ const Index = () => {
     if (score > highScore) {
       setHighScore(score);
     }
+    setSessionPowerUps([]);
+    refreshProgress();
     setScreen("reveal");
   };
 
   const handleContinueFromReveal = () => {
-    setScreen("start");
+    setScreen("quest-map");
   };
+
+  const handleEarnStarsInGame = (stars: number) => {
+    if (stars > 0) {
+      awardStars(stars);
+      refreshProgress();
+    }
+  };
+
+  const handleUnlockSkin = (skinId: string, cost: number) => {
+    if (!spendStars(cost)) {
+      toast.error("Not enough stars yet. Try a challenge!", { duration: 2000 });
+      return;
+    }
+    unlockCreativeSkin(skinId);
+    refreshProgress();
+  };
+
+  const handleEquipSkin = (skinId: string) => {
+    setActiveSkin(skinId);
+    refreshProgress();
+  };
+
+  const handleSaveLeaderboardProfile = (profile: { nickname: string; classCode?: string; percentileBand?: string }) => {
+    updateLeaderboardProfile(profile);
+    refreshProgress();
+    setScreen("progress");
+  };
+
+  const currentChapter = selectedChapterId ? questChapters.find(chapter => chapter.id === selectedChapterId) : null;
+  const chapterTopicIds = currentChapter ? getChapterTopics(currentChapter.id).map(topic => topic.id) : undefined;
+
+  const averageScore = playerProgress.quizAttempts.length
+    ? playerProgress.quizAttempts.reduce((sum, quiz) => sum + quiz.score, 0) / playerProgress.quizAttempts.length
+    : 0;
+  const percentile = Math.min(99, Math.max(5, Math.round(averageScore)));
+
+  const leaderboardProfile = playerProgress.leaderboardProfile;
 
   return (
     <>
@@ -120,6 +319,13 @@ const Index = () => {
           onViewTopics={handleViewTopics}
           onViewFounders={handleViewFounders}
           onViewProgress={handleViewProgress}
+          onViewParent={handleOpenParent}
+          onViewLeaderboard={handleViewLeaderboard}
+          onOpenCreative={handleOpenCreative}
+          onToggleSimpleMode={() => setSimpleMode(!simpleMode)}
+          onToggleSpeech={() => setSpeechEnabled(!speechEnabled)}
+          simpleMode={simpleMode}
+          speechEnabled={speechEnabled}
           highScore={highScore}
         />
       )}
@@ -129,11 +335,24 @@ const Index = () => {
           onBack={handleBackToStart}
         />
       )}
-      {screen === "topic-select" && (
+      {screen === "quest-map" && (
+        <QuestMap
+          onBack={handleBackToModes}
+          onOpenChapter={handleOpenChapter}
+          chapterProgress={playerProgress.chapterProgress}
+          stars={playerProgress.stars}
+          simpleMode={simpleMode}
+        />
+      )}
+      {screen === "topic-select" && currentChapter && (
         <TopicSelector
           onSelectTopic={handleTopicSelect}
-          onBack={handleBackToModes}
+          onBack={handleBackToQuestMap}
+          onBackToMap={handleBackToQuestMap}
           mode={selectedMode}
+          availableTopicIds={chapterTopicIds}
+          chapterTitle={currentChapter.title}
+          simpleMode={simpleMode}
         />
       )}
       {screen === "lesson" && selectedTopicId && (
@@ -141,37 +360,38 @@ const Index = () => {
           topicId={selectedTopicId}
           mode={selectedMode}
           onComplete={handleLessonComplete}
-          onBack={handleBackToTopics}
+          onBack={handleBackToQuestMap}
         />
       )}
-      {screen === "assessment" && selectedTopicId && (() => {
-        const topic = educationalTopics.find(t => t.id === selectedTopicId);
-        if (!topic) return null;
-        
-        const questions = topic.assessmentQuestions || 
-          require('@/utils/questionBank').generateAssessmentQuestions(
-            topic.id,
-            topic.question,
-            topic.options,
-            topic.correctAnswer,
-            topic.explanation
-          );
-        
-        return (
-          <AssessmentGate
-            topicId={selectedTopicId}
-            topicTitle={topic.title}
-            questions={questions}
-            onPass={handleAssessmentPass}
-            onRetry={handleAssessmentRetry}
-          />
-        );
-      })()}
+      {screen === "assessment" && selectedTopic && assessmentQuestions && (
+        <AssessmentGate
+          topicId={selectedTopic.id}
+          topicTitle={selectedTopic.title}
+          questions={assessmentQuestions}
+          onPass={handleAssessmentPass}
+          onRetry={handleAssessmentRetry}
+          simpleMode={simpleMode}
+          speechEnabled={speechEnabled}
+        />
+      )}
+      {screen === "micro-challenge" && activeChallenge && (
+        <MicroChallengeCard
+          challenge={activeChallenge}
+          onFinish={handleMicroChallengeFinish}
+          simpleMode={simpleMode}
+          enableSpeech={speechEnabled}
+        />
+      )}
       {screen === "game" && (
-        <EndlessRunner 
-          onGameOver={handleGameOver} 
+        <EndlessRunner
+          onGameOver={handleGameOver}
           onHome={handleBackToStart}
           topicId={selectedTopicId || undefined}
+          activePowerUps={sessionPowerUps}
+          onPowerUpConsumed={() => setSessionPowerUps([])}
+          onEarnStars={handleEarnStarsInGame}
+          simpleMode={simpleMode}
+          skin={playerProgress.creative.activeSkin}
         />
       )}
       {screen === "reveal" && (
@@ -184,9 +404,40 @@ const Index = () => {
       {screen === "library" && <TopicsLibrary onBack={handleBackToStart} />}
       {screen === "founders" && <FoundersStory onBack={handleBackToStart} />}
       {screen === "progress" && (
-        <ProgressDashboard 
+        <ProgressDashboard
           onBack={handleBackToStart}
           onReviewTopic={handleReviewTopic}
+          onOpenParent={handleOpenParent}
+          onOpenCreative={handleOpenCreative}
+          simpleMode={simpleMode}
+        />
+      )}
+      {screen === "leaderboard" && (
+        <LeaderboardPanel
+          onBack={handleBackToStart}
+          percentile={percentile}
+          averageScore={averageScore}
+          profile={leaderboardProfile}
+          onSaveProfile={handleSaveLeaderboardProfile}
+          simpleMode={simpleMode}
+        />
+      )}
+      {screen === "creative" && (
+        <CreativeStudio
+          stars={playerProgress.stars}
+          unlockedSkins={playerProgress.creative.unlockedSkins}
+          activeSkin={playerProgress.creative.activeSkin}
+          onUnlock={handleUnlockSkin}
+          onEquip={handleEquipSkin}
+          onBack={handleBackToStart}
+          simpleMode={simpleMode}
+        />
+      )}
+      {screen === "parent" && (
+        <ParentTeacherView
+          onBack={handleBackToStart}
+          progress={playerProgress}
+          simpleMode={simpleMode}
         />
       )}
     </>

--- a/src/types/userProgress.ts
+++ b/src/types/userProgress.ts
@@ -1,3 +1,52 @@
+export interface PowerUpInventory {
+  id: string;
+  quantity: number;
+  lastEarned?: Date;
+}
+
+export interface BadgeProgress {
+  id: string;
+  tier: 1 | 2 | 3;
+  earnedAt: Date;
+}
+
+export interface StickerAlbumEntry {
+  topicId: number;
+  tiersUnlocked: number[];
+}
+
+export interface StreakState {
+  dailyCount: number;
+  weeklyCount: number;
+  lastSessionDate: Date | null;
+  catchUpTokens: number;
+}
+
+export interface ChapterProgress {
+  chapterId: string;
+  unlocked: boolean;
+  completedTopicIds: number[];
+  badgeTier: 0 | 1 | 2 | 3;
+}
+
+export interface PracticeWorksheet {
+  id: string;
+  topicId: number;
+  createdAt: Date;
+  questions: string[];
+}
+
+export interface CreativeUnlocks {
+  unlockedSkins: string[];
+  activeSkin?: string;
+}
+
+export interface LeaderboardProfile {
+  nickname: string;
+  classCode?: string;
+  percentileBand?: string;
+}
+
 export interface UserProgress {
   topicsCompleted: number[];
   topicsInProgress: number[];
@@ -21,6 +70,17 @@ export interface UserProgress {
     topicId: number;
     date: Date;
   }[];
+  stars: number;
+  powerUps: PowerUpInventory[];
+  badges: BadgeProgress[];
+  stickerAlbum: StickerAlbumEntry[];
+  streak: StreakState;
+  chapterProgress: ChapterProgress[];
+  practiceHistory: PracticeWorksheet[];
+  totalLearningMinutes: number;
+  lastSessionDate: Date | null;
+  leaderboardProfile?: LeaderboardProfile;
+  creative: CreativeUnlocks;
 }
 
 export interface LearningSession {

--- a/src/utils/progressStorage.ts
+++ b/src/utils/progressStorage.ts
@@ -1,4 +1,12 @@
-import { UserProgress } from "@/types/userProgress";
+import {
+  type BadgeProgress,
+  type ChapterProgress,
+  type LeaderboardProfile,
+  type PowerUpInventory,
+  type PracticeWorksheet,
+  type StickerAlbumEntry,
+  type UserProgress,
+} from "@/types/userProgress";
 
 const STORAGE_KEY = "snakerunner_progress";
 
@@ -12,9 +20,27 @@ export const getStoredProgress = (): UserProgress => {
       quizAttempts: [],
       masteryLevels: [],
       nextReviewDate: [],
+      stars: 0,
+      powerUps: [],
+      badges: [],
+      stickerAlbum: [],
+      streak: {
+        dailyCount: 0,
+        weeklyCount: 0,
+        lastSessionDate: null,
+        catchUpTokens: 2,
+      },
+      chapterProgress: [],
+      practiceHistory: [],
+      totalLearningMinutes: 0,
+      lastSessionDate: null,
+      creative: {
+        unlockedSkins: ["classic"],
+        activeSkin: "classic",
+      },
     };
   }
-  
+
   const parsed = JSON.parse(stored);
   // Convert date strings back to Date objects
   parsed.lessonsViewed = parsed.lessonsViewed.map((item: any) => ({
@@ -25,8 +51,55 @@ export const getStoredProgress = (): UserProgress => {
     ...item,
     date: new Date(item.date),
   }));
-  
+
+  parsed.badges = (parsed.badges || []).map((badge: BadgeProgress) => ({
+    ...badge,
+    earnedAt: new Date(badge.earnedAt),
+  }));
+
+  parsed.practiceHistory = (parsed.practiceHistory || []).map(
+    (worksheet: PracticeWorksheet) => ({
+      ...worksheet,
+      createdAt: new Date(worksheet.createdAt),
+    }),
+  );
+
+  parsed.powerUps = (parsed.powerUps || []).map((powerUp: PowerUpInventory) => ({
+    ...powerUp,
+    lastEarned: powerUp.lastEarned ? new Date(powerUp.lastEarned) : undefined,
+  }));
+
+  parsed.streak = parsed.streak || {
+    dailyCount: 0,
+    weeklyCount: 0,
+    lastSessionDate: null,
+    catchUpTokens: 2,
+  };
+  if (parsed.streak.lastSessionDate) {
+    parsed.streak.lastSessionDate = new Date(parsed.streak.lastSessionDate);
+  }
+
+  parsed.chapterProgress = (parsed.chapterProgress || []).map(
+    (chapter: ChapterProgress) => ({ ...chapter }),
+  );
+
+  parsed.stickerAlbum = (parsed.stickerAlbum || []).map(
+    (sticker: StickerAlbumEntry) => ({ ...sticker }),
+  );
+
+  parsed.totalLearningMinutes = parsed.totalLearningMinutes || 0;
+  parsed.lastSessionDate = parsed.lastSessionDate
+    ? new Date(parsed.lastSessionDate)
+    : null;
+
+  parsed.stars = parsed.stars ?? 0;
+  parsed.creative = parsed.creative || {
+    unlockedSkins: ["classic"],
+    activeSkin: "classic",
+  };
+
   return parsed;
+
 };
 
 export const saveProgress = (progress: UserProgress) => {
@@ -90,4 +163,180 @@ export const updateMasteryLevel = (topicId: number, level: "beginner" | "interme
   }
   
   saveProgress(progress);
+};
+
+export const awardStars = (amount: number) => {
+  const progress = getStoredProgress();
+  progress.stars = Math.max(0, (progress.stars || 0) + amount);
+  saveProgress(progress);
+  return progress.stars;
+};
+
+export const spendStars = (amount: number) => {
+  const progress = getStoredProgress();
+  if ((progress.stars || 0) < amount) {
+    return false;
+  }
+  progress.stars -= amount;
+  saveProgress(progress);
+  return true;
+};
+
+export const grantPowerUp = (id: string, quantity = 1) => {
+  const progress = getStoredProgress();
+  const inventory = progress.powerUps || [];
+  const existing = inventory.find(power => power.id === id);
+  if (existing) {
+    existing.quantity += quantity;
+    existing.lastEarned = new Date();
+  } else {
+    inventory.push({ id, quantity, lastEarned: new Date() });
+  }
+  progress.powerUps = inventory;
+  saveProgress(progress);
+  return progress.powerUps;
+};
+
+export const updateStickerAlbum = (topicId: number, tier: number) => {
+  const progress = getStoredProgress();
+  const entry = (progress.stickerAlbum || []).find(item => item.topicId === topicId);
+  if (entry) {
+    if (!entry.tiersUnlocked.includes(tier)) {
+      entry.tiersUnlocked.push(tier);
+    }
+  } else {
+    progress.stickerAlbum.push({ topicId, tiersUnlocked: [tier] });
+  }
+  saveProgress(progress);
+  return progress.stickerAlbum;
+};
+
+export const unlockChapter = (chapterId: string) => {
+  const progress = getStoredProgress();
+  const chapters = progress.chapterProgress || [];
+  const entry = chapters.find(chapter => chapter.chapterId === chapterId);
+  if (entry) {
+    entry.unlocked = true;
+  } else {
+    chapters.push({ chapterId, unlocked: true, completedTopicIds: [], badgeTier: 0 });
+  }
+  progress.chapterProgress = chapters;
+  saveProgress(progress);
+  return progress.chapterProgress;
+};
+
+export const recordChapterCompletion = (chapterId: string, topicId: number) => {
+  const progress = getStoredProgress();
+  const entry = progress.chapterProgress.find(chapter => chapter.chapterId === chapterId);
+  if (entry) {
+    if (!entry.completedTopicIds.includes(topicId)) {
+      entry.completedTopicIds.push(topicId);
+    }
+    const completionRatio = entry.completedTopicIds.length;
+    if (completionRatio >= 9) {
+      entry.badgeTier = 3;
+    } else if (completionRatio >= 6) {
+      entry.badgeTier = Math.max(entry.badgeTier, 2);
+    } else if (completionRatio >= 3) {
+      entry.badgeTier = Math.max(entry.badgeTier, 1);
+    }
+  } else {
+    progress.chapterProgress.push({
+      chapterId,
+      unlocked: true,
+      completedTopicIds: [topicId],
+      badgeTier: 1,
+    });
+  }
+  saveProgress(progress);
+  return progress.chapterProgress;
+};
+
+export const recordBadge = (id: string, tier: 1 | 2 | 3) => {
+  const progress = getStoredProgress();
+  const existing = progress.badges.find(badge => badge.id === id && badge.tier === tier);
+  if (!existing) {
+    progress.badges.push({ id, tier, earnedAt: new Date() });
+    saveProgress(progress);
+  }
+  return progress.badges;
+};
+
+export const logPracticeWorksheet = (worksheet: PracticeWorksheet) => {
+  const progress = getStoredProgress();
+  progress.practiceHistory.push({ ...worksheet, createdAt: new Date(worksheet.createdAt) });
+  saveProgress(progress);
+  return progress.practiceHistory;
+};
+
+export const updateLeaderboardProfile = (profile: LeaderboardProfile) => {
+  const progress = getStoredProgress();
+  progress.leaderboardProfile = profile;
+  saveProgress(progress);
+  return progress.leaderboardProfile;
+};
+
+export const unlockCreativeSkin = (skinId: string) => {
+  const progress = getStoredProgress();
+  if (!progress.creative.unlockedSkins.includes(skinId)) {
+    progress.creative.unlockedSkins.push(skinId);
+  }
+  progress.creative.activeSkin = skinId;
+  saveProgress(progress);
+  return progress.creative;
+};
+
+export const setActiveSkin = (skinId: string) => {
+  const progress = getStoredProgress();
+  progress.creative.activeSkin = skinId;
+  saveProgress(progress);
+  return progress.creative;
+};
+
+export const updateLearningMinutes = (minutes: number) => {
+  const progress = getStoredProgress();
+  progress.totalLearningMinutes = (progress.totalLearningMinutes || 0) + minutes;
+  progress.lastSessionDate = new Date();
+  saveProgress(progress);
+  return progress.totalLearningMinutes;
+};
+
+export const updateStreak = (sessionDate = new Date()) => {
+  const progress = getStoredProgress();
+  const lastSession = progress.streak.lastSessionDate;
+  const currentDate = new Date(sessionDate.toDateString());
+  const yesterday = new Date(currentDate);
+  yesterday.setDate(currentDate.getDate() - 1);
+
+  if (!lastSession) {
+    progress.streak.dailyCount = 1;
+    progress.streak.weeklyCount = 1;
+  } else {
+    const last = new Date(lastSession.toString());
+    const lastDate = new Date(last.toDateString());
+    if (lastDate.getTime() === yesterday.getTime()) {
+      progress.streak.dailyCount += 1;
+    } else if (lastDate.getTime() !== currentDate.getTime()) {
+      if (progress.streak.catchUpTokens > 0) {
+        progress.streak.catchUpTokens -= 1;
+        progress.streak.dailyCount += 1;
+      } else {
+        progress.streak.dailyCount = 1;
+      }
+    }
+
+    const weekStart = new Date(currentDate);
+    weekStart.setDate(currentDate.getDate() - currentDate.getDay());
+    const lastWeekStart = new Date(lastDate);
+    lastWeekStart.setDate(lastDate.getDate() - lastDate.getDay());
+    if (weekStart.getTime() === lastWeekStart.getTime()) {
+      progress.streak.weeklyCount = Math.max(progress.streak.weeklyCount, progress.streak.dailyCount);
+    } else {
+      progress.streak.weeklyCount = progress.streak.dailyCount;
+    }
+  }
+
+  progress.streak.lastSessionDate = currentDate;
+  saveProgress(progress);
+  return progress.streak;
 };


### PR DESCRIPTION
## Summary
- introduce a chapter-based quest map with gated assessments, micro-challenges, and session power-ups for the arcade game
- expand progress tracking with stars, streaks, badges, sticker album, safe leaderboards, and a creative studio for unlockable snake skins
- add parent/teacher snapshots, printable practice sets, text-to-speech toggles, and readability options throughout the learning flow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1f6cd98b8832c8427c7abb3a25b68